### PR TITLE
added subworkflow for variant calling  with bcftools/mpileup and call…

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -41,6 +41,13 @@ params {
             adapter_fasta     = "${baseDir}/assets/adapters.fas"
             publish_files     = ['json':'', 'html':'', 'log': 'log']
         }
+        'bcftools_mpileup_options' {
+            args          = '--min-BQ 20'
+            args2         = '--multiallelic-caller --variants-only'
+            args3         = "--include 'INFO/DP>=10'"
+            publish_files = ['gz':'', 'gz.tbi':'', 'stats.txt':'bcftools_stats']
+            publish_dir   = 'variants/bcftools'
+        }
         'multiqc' {
             args = ""
         }

--- a/main.nf
+++ b/main.nf
@@ -81,6 +81,8 @@ include { GET_SOFTWARE_VERSIONS } from './modules/local/get_software_versions' a
 // Local: Sub-workflows
 include { INPUT_CHECK } from './modules/local/subworkflow/input_check' addParams( options: [:] )
 include { BAM_SORT_SAMTOOLS } from './modules/local/subworkflow/bam_sort_samtools' addParams( samtools_sort_options: modules['samtools_sort_options'], samtools_index_options : modules['samtools_index_options'], bam_stats_options: modules['bam_stats_options'])
+include { VARIANTS_BCFTOOLS } from './modules/local/subworkflow/variants_bcftools' addParams( bcftools_mpileup_options: modules['bcftools_mpileup_options'])
+
 ////////////////////////////////////////////////////
 /* --    IMPORT NF-CORE MODULES/SUBWORKFLOWS   -- */
 ////////////////////////////////////////////////////
@@ -144,6 +146,14 @@ workflow {
      */
     BAM_SORT_SAMTOOLS ( 
         BWA_MEM.out.bam
+    )
+
+       /*
+     * SUBWORKFLOW: Call variants
+     */
+    VARIANTS_BCFTOOLS ( 
+        BAM_SORT_SAMTOOLS.out.bam,
+        ch_reference
     )
     
 

--- a/modules/local/subworkflow/variants_bcftools.nf
+++ b/modules/local/subworkflow/variants_bcftools.nf
@@ -1,0 +1,26 @@
+/*
+ * Variant calling and downstream processing for BCFTools
+ */
+
+params.bcftools_mpileup_options    = [:]
+
+include { BCFTOOLS_MPILEUP } from '../../nf-core/software/bcftools/mpileup/main' addParams( options: params.bcftools_mpileup_options )
+
+workflow VARIANTS_BCFTOOLS {
+    take:
+    bam       // channel: [ val(meta), [ bam ] ]
+    fasta     // channel: /path/to/genome.fasta
+    
+    main:
+    /*
+     * Call variants
+     */
+    BCFTOOLS_MPILEUP ( bam, fasta )
+
+    emit:
+    vcf              = BCFTOOLS_MPILEUP.out.vcf     // channel: [ val(meta), [ vcf ] ]
+    tbi              = BCFTOOLS_MPILEUP.out.tbi     // channel: [ val(meta), [ tbi ] ]
+    stats            = BCFTOOLS_MPILEUP.out.stats   // channel: [ val(meta), [ txt ] ]
+    bcftools_version = BCFTOOLS_MPILEUP.out.version //    path: *.version.txt
+
+}

--- a/modules/nf-core/software/bcftools/filter/functions.nf
+++ b/modules/nf-core/software/bcftools/filter/functions.nf
@@ -1,0 +1,60 @@
+
+/*
+ * -----------------------------------------------------
+ *  Utility functions used in nf-core DSL2 module files
+ * -----------------------------------------------------
+ */
+
+/*
+ * Extract name of software tool from process name using $task.process
+ */
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+/*
+ * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+ */
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args          = args.args ?: ''
+    options.args2         = args.args2 ?: ''
+    options.publish_by_id = args.publish_by_id ?: false
+    options.publish_dir   = args.publish_dir ?: ''
+    options.publish_files = args.publish_files
+    options.suffix        = args.suffix ?: ''
+    return options
+}
+
+/*
+ * Tidy up and join elements of a list to return a path string
+ */
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
+    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+/*
+ * Function to save/publish module results
+ */
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_id) {
+            path_list.add(args.publish_id)
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/modules/nf-core/software/bcftools/filter/main.nf
+++ b/modules/nf-core/software/bcftools/filter/main.nf
@@ -1,0 +1,39 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process BCFTOOLS_FILTER {
+    tag "$meta.id"
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+
+    conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/bcftools:1.11--h7c999a4_0"
+    } else {
+        container "quay.io/biocontainers/bcftools:1.11--h7c999a4_0"
+    }
+
+    input:
+    tuple val(meta), path(vcf)
+
+    output:
+    tuple val(meta), path("*.gz"), emit: vcf
+    path  "*.version.txt"        , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    """
+    bcftools filter \\
+        --output ${prefix}.vcf.gz \\
+        $options.args \\
+        $vcf
+
+    echo \$(bcftools --version 2>&1) | sed 's/^.*bcftools //; s/ .*\$//' > ${software}.version.txt
+    """
+}

--- a/modules/nf-core/software/bcftools/filter/meta.yml
+++ b/modules/nf-core/software/bcftools/filter/meta.yml
@@ -1,0 +1,40 @@
+name: bcftools_filter
+description: Filters VCF files
+keywords:
+    - variant calling
+    - filtering
+    - VCF
+tools:
+    - filter:
+        description: |
+          Apply fixed-threshold filters to VCF files.
+        homepage: http://samtools.github.io/bcftools/bcftools.html
+        documentation: http://www.htslib.org/doc/bcftools.html
+        doi: 10.1093/bioinformatics/btp352
+input:
+    - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcf:
+        type: file
+        description: VCF input file
+        pattern: "*.{vcf}"
+output:
+    - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcf:
+        type: file
+        description: VCF filtered output file
+        pattern: "*.{vcf}"
+    - version:
+        type: file
+        description: File containing software version
+        pattern: "*.{version.txt}"
+authors:
+    - "@joseespinosa"
+    - "@drpatelh"


### PR DESCRIPTION
…, still needs to filter

Since the nf-core module bcftools/mpileup does include 'view', would it be enough for filtering purposes? Then we wouldn't need a subworkflow fusing bcftools/mpileup and bcftools/filter, only the first module

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/bactmap branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/bactmap)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/bactmap/tree/master/.github/CONTRIBUTING.md
