### PR TITLE
chore: remove redundand path segment

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -23,7 +23,7 @@ params {
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
     // Input data for full size test
-    input = params.pipelines_testdata_base_path + '/bactmap/samplesheet.csv'
+    input = params.pipelines_testdata_base_path + 'bactmap/samplesheet.csv'
     // Genome references
 
     reference = params.pipelines_testdata_base_path + 'modules/data/genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz'

--- a/conf/test.config
+++ b/conf/test.config
@@ -23,8 +23,8 @@ params {
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
     // Input data for full size test
-    input = params.pipelines_testdata_base_path + 'test-datasets/bactmap/samplesheet.csv'
-    
+    input = params.pipelines_testdata_base_path + '/bactmap/samplesheet.csv'
     // Genome references
+
     reference = params.pipelines_testdata_base_path + 'modules/data/genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -15,7 +15,7 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
-    input = params.pipelines_testdata_base_path + 'test-datasets/bactmap/samplesheet.csv'
+    input = params.pipelines_testdata_base_path + 'bactmap/samplesheet.csv'
 
     // Genome references
     reference = params.pipelines_testdata_base_path + 'modules/data/genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz'


### PR DESCRIPTION
This PR removes redundant path segment from the nextflow test configurations samplesheet parameter
<!--
# nf-core/bactmap pull request

Many thanks for contributing to nf-core/bactmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bactmap/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bactmap/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/bactmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
