### PR TITLE
fix: ensure the logic of ONT parsing is correct

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -24,13 +24,13 @@
                 "enum": ["ILLUMINA", "OXFORD_NANOPORE"],
                 "errorMessage": "One of ILLUMINA or OXFORD_NANOPORE must be provided.",
                 "meta": ["instrument_platform"]
-
             },
             "fastq_1": {
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
                 "pattern": "^\\S+\\.f(ast)?q\\.gz$",
+                "default": null,
                 "errorMessage": "FastQ file for reads 1 must be provided, cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
             },
             "fastq_2": {
@@ -38,10 +38,10 @@
                 "format": "file-path",
                 "exists": true,
                 "pattern": "^\\S+\\.f(ast)?q\\.gz$",
+                "default": null,
                 "errorMessage": "FastQ file for reads 2 cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
             }
-           
         },
-        "required": ["sample","run_accession", "instrument_platform", "fastq_1"]
+        "required": ["sample", "run_accession", "instrument_platform", "fastq_1"]
     }
 }

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -30,7 +30,6 @@
                 "format": "file-path",
                 "exists": true,
                 "pattern": "^\\S+\\.f(ast)?q\\.gz$",
-                "default": null,
                 "errorMessage": "FastQ file for reads 1 must be provided, cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
             },
             "fastq_2": {
@@ -38,7 +37,6 @@
                 "format": "file-path",
                 "exists": true,
                 "pattern": "^\\S+\\.f(ast)?q\\.gz$",
-                "default": null,
                 "errorMessage": "FastQ file for reads 2 cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
             }
         },

--- a/workflows/bactmap.nf
+++ b/workflows/bactmap.nf
@@ -120,7 +120,7 @@ workflow BACTMAP {
             }
             meta.single_end = !fastq_2
 
-            if (meta.single_end && meta.instrument_platform == 'OXFORD_NANOPORE') {
+            if (meta.instrument_platform == 'OXFORD_NANOPORE' && !meta.single_end) {
                 error("Error: Please check input samplesheet: for Oxford Nanopore reads entry `fastq_2` should be empty!")
             }
         }


### PR DESCRIPTION
# Context

This PR ensures the error is thrown when the  samplesheet row at the same time have specified `OXFORD_NANOPORE` instrument platform and `fastq_2`

<!--
# nf-core/bactmap pull request

Many thanks for contributing to nf-core/bactmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bactmap/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bactmap/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/bactmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
