### PR TITLE
Add subworkflow mapping statistics

### DIFF
--- a/bin/seqtk_parser.py
+++ b/bin/seqtk_parser.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import glob
+import argparse
+import pandas as pd
+
+
+def parser_args(args=None):
+    """
+    Function for input arguments for seqtk_parser.py
+    """
+    Description = "Collect seqtk comp outputs and create a summary table"
+    Epilog = """Example usage: python seqtk_parser.py """
+    parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
+    parser.add_argument(
+        "-of",
+        "--output_file",
+        type=str,
+        default="mapping_summary.tsv",
+        help="seqtk comp summary file (default: 'mapping_summary.tsv').",
+    )
+    return parser.parse_args(args)
+
+
+def make_dir(path):
+    """
+    Function for making a directory from a provided path
+    """
+    if not len(path) == 0:
+        try:
+            os.makedirs(path)
+        except OSError as exception:
+            if exception.errno != errno.EEXIST:
+                raise
+
+
+def seqtk_to_dataframe(file_list):
+    """
+    Function for creating a dataframe from a list of seqtk comp files
+    """
+    seqtk_file_list = [pd.read_csv(f, sep="\t", header=None) for f in file_list]
+    seqtk_df = pd.concat(seqtk_file_list, ignore_index=True)
+    seqtk_df = seqtk_df.iloc[:, 0:6]
+    seqtk_df.columns = ["sample", "ref_length", "#A", "#C", "#G", "#T"]
+    column_list = ["#A", "#C", "#G", "#T"]
+    seqtk_df["mapped"] = seqtk_df[column_list].sum(axis=1)
+    seqtk_df["%ref mapped"] = seqtk_df["mapped"] / seqtk_df["ref_length"] * 100
+
+    return seqtk_df
+
+
+def main(args=None):
+    args = parser_args(args)
+
+    ## Create output directory if it doesn't exist
+    out_dir = os.path.dirname(args.output_file)
+    make_dir(out_dir)
+
+    ## Create list of seqtk comp tsv outputs
+    seqtk_files = sorted(glob.glob("*.tsv"))
+
+    ## Create dataframe
+    seqtk_df = seqtk_to_dataframe(seqtk_files)
+
+    ## Write output file
+    seqtk_df.to_csv(args.output_file, sep="\t", header=True, index=False)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -348,6 +348,20 @@ process {
 
     withName: 'SEQTK_COMP' {
         ext.agrs = ''
+        publishDir = [
+            path: { "${params.outdir}/seqtk/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.tsv'
+        ]
+    }
+
+    withName: 'SEQTK_PARSE' {
+        ext.agrs = ''
+        publishDir = [
+            path: { "${params.outdir}/seqtk/" },
+            mode: params.publish_dir_mode,
+            pattern: 'mapping_summary.tsv'
+        ]
     }
 
     withName: 'CLAIR3' {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -370,7 +370,7 @@
         },
         {
             "$ref": "#/$defs/generic_options"
-        },
+        }
     ],
     "properties": {
         "reference": {

--- a/subworkflows/local/mapping_statistics.nf
+++ b/subworkflows/local/mapping_statistics.nf
@@ -1,0 +1,30 @@
+//
+// Summarize mappping statistics with SEQTK
+//
+
+include { SEQTK_COMP } from '../../modules/nf-core/seqtk/comp/main'
+include { SEQTK_PARSE } from '../../modules/local/seqtk_parse/main'
+
+workflow MAPPING_STATISTICS {
+   take:
+   fasta // [[meta], [fasta]]
+
+   main:
+   ch_versions = Channel.empty()
+
+   SEQTK_COMP( fasta )
+   ch_versions = ch_versions.mix( SEQTK_COMP.out.versions )
+
+   ch_seqtk_stats  =  SEQTK_COMP.out.seqtk_stats
+                       .map( it -> it[1])
+                       .collect()
+
+   SEQTK_PARSE( ch_seqtk_stats )
+   ch_versions = ch_versions.mix( SEQTK_PARSE.out.versions )
+
+   emit:
+   ch_mapping_stats = SEQTK_PARSE.out.tsv // Channel: [ mapping_summary.tsv ]
+   ch_versions      // Channel: [ version.yml ]
+
+}
+

--- a/workflows/bactmap.nf
+++ b/workflows/bactmap.nf
@@ -47,6 +47,7 @@ if ( params.input ) {
 //include { SEQTK_PARSE                                } from '../modules/local/seqtk_parse/main'
 //include { ALIGNPSEUDOGENOMES                         } from '../modules/local/alignpseudogenomes/main'
 
+include { MAPPING_STATISTICS                         } from '../subworkflows/local/mapping_statistics'
 include { SHORTREAD_PREPROCESSING                    } from '../subworkflows/local/shortread_preprocessing'
 include { LONGREAD_PREPROCESSING                     } from '../subworkflows/local/longread_processing'
 //include { SHORTREAD_MAPPING                          } from '../subworkflows/local/shortread_mapping/main'
@@ -341,7 +342,8 @@ workflow BACTMAP {
         []
     )
 
-    emit:multiqc_report = MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
+    emit:
+    multiqc_report = MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
     versions       = ch_versions                 // channel: [ path(versions.yml) ]
 
 }


### PR DESCRIPTION
Add subworkflow MAPPING_STATISTICS  #129 with:
- [x] seqtk comp
- [x] seqtk parse

Note: This subworkflow processes the output FASTA file from vcf2pseudogenome.py. However, this module has not yet been integrated into the main workflow. Therefore, mapping_statistics has been tested using independent data with a separate input channel.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bactmap/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/bactmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
